### PR TITLE
Modify `isIndex` function to cover wider case

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,10 +187,10 @@ Determine if this layer is sliced. You can pass the folder of a layer or the nam
 #### `getIndex`
 
 ```ts
-function getIndex(fileOrFolder: File | Folder): File | undefined;
+function getIndex(fileOrFolder: File | Folder): File[];
 ```
 
-Get the index (public API) of a slice or segment. When a segment is a file, it is its own index.
+Get the index (public API) of a slice or segment. When a segment is a file, it is its own index. When a segment is a folder, it returns an array of index files within that folder. Multiple index files (e.g., `index.client.js`, `index.server.js`) are supported.
 
 #### `isIndex`
 

--- a/README.md
+++ b/README.md
@@ -184,10 +184,10 @@ function isSliced(layerOrName: Folder | LayerName): boolean;
 
 Determine if this layer is sliced. You can pass the folder of a layer or the name (lowercase). Only layers Shared and App are not sliced, the rest are.
 
-#### `getIndex`
+#### `getIndexes`
 
 ```ts
-function getIndex(fileOrFolder: File | Folder): File[];
+function getIndexes(fileOrFolder: File | Folder): File[];
 ```
 
 Get the index (public API) of a slice or segment. When a segment is a file, it is its own index. When a segment is a folder, it returns an array of index files within that folder. Multiple index files (e.g., `index.client.js`, `index.server.js`) are supported.

--- a/src/fsd-aware-traverse.ts
+++ b/src/fsd-aware-traverse.ts
@@ -157,7 +157,7 @@ export function isSliced(layerOrName: Folder | LayerName): boolean {
  * When a segment is a folder, it returns an array of index files within that folder.
  * Multiple index files (e.g., `index.client.js`, `index.server.js`) are supported.
  */
-export function getIndex(fileOrFolder: File | Folder): File[] {
+export function getIndexes(fileOrFolder: File | Folder): File[] {
   if (fileOrFolder.type === "file") {
     return [fileOrFolder];
   }

--- a/src/fsd-aware-traverse.ts
+++ b/src/fsd-aware-traverse.ts
@@ -165,6 +165,15 @@ export function getIndex(fileOrFolder: File | Folder): File | undefined {
 
 /** Determine if a given file or folder is an index file. */
 export function isIndex(fileOrFolder: File | Folder): boolean {
+  if (fileOrFolder.type === "file") {
+    const Seperator = ".";
+    const parsedFileName = parse(fileOrFolder.path).name;
+
+    return parsedFileName.split(Seperator).at(0) === "index";
+  }
+
+  return false;
+
   return (
     fileOrFolder.type === "file" && parse(fileOrFolder.path).name === "index"
   );

--- a/src/fsd-aware-traverse.ts
+++ b/src/fsd-aware-traverse.ts
@@ -154,29 +154,27 @@ export function isSliced(layerOrName: Folder | LayerName): boolean {
  * Get the index (public API) of a slice or segment.
  *
  * When a segment is a file, it is its own index.
+ * When a segment is a folder, it returns an array of index files within that folder.
+ * Multiple index files (e.g., `index.client.js`, `index.server.js`) are supported.
  */
-export function getIndex(fileOrFolder: File | Folder): File | undefined {
+export function getIndex(fileOrFolder: File | Folder): File[] {
   if (fileOrFolder.type === "file") {
-    return fileOrFolder;
-  } else {
-    return fileOrFolder.children.find(isIndex) as File | undefined;
+    return [fileOrFolder];
   }
+
+  return fileOrFolder.children.filter(isIndex);
 }
 
 /** Determine if a given file or folder is an index file. */
 export function isIndex(fileOrFolder: File | Folder): boolean {
   if (fileOrFolder.type === "file") {
-    const Seperator = ".";
+    const separator = ".";
     const parsedFileName = parse(fileOrFolder.path).name;
 
-    return parsedFileName.split(Seperator).at(0) === "index";
+    return parsedFileName.split(separator).at(0) === "index";
   }
 
   return false;
-
-  return (
-    fileOrFolder.type === "file" && parse(fileOrFolder.path).name === "index"
-  );
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ export {
   getAllSlices,
   getAllSegments,
   isSliced,
-  getIndex,
+  getIndexes,
   isSlice,
   isIndex,
   isCrossImportPublicApi,

--- a/src/specs/fsd-aware-traverse.spec.ts
+++ b/src/specs/fsd-aware-traverse.spec.ts
@@ -141,19 +141,21 @@ describe("getIndex", () => {
       `,
       joinFromRoot("project", "src", "entities", "user", "ui"),
     );
-    expect(getIndex(indexFile)).toEqual(indexFile);
-    expect(getIndex(fileSegment)).toEqual(fileSegment);
-    expect(getIndex(folderSegment)).toEqual({
-      type: "file",
-      path: joinFromRoot(
-        "project",
-        "src",
-        "entities",
-        "user",
-        "ui",
-        "index.ts",
-      ),
-    });
+    expect(getIndex(indexFile)).toEqual([indexFile]);
+    expect(getIndex(fileSegment)).toEqual([fileSegment]);
+    expect(getIndex(folderSegment)).toEqual([
+      {
+        type: "file",
+        path: joinFromRoot(
+          "project",
+          "src",
+          "entities",
+          "user",
+          "ui",
+          "index.ts",
+        ),
+      },
+    ]);
   });
 
   test("recognizes index.server.js as index file", () => {
@@ -174,19 +176,58 @@ describe("getIndex", () => {
       joinFromRoot("project", "src", "entities", "user", "ui"),
     );
 
-    expect(getIndex(indexServerFile)).toEqual(indexServerFile);
-    expect(getIndex(nonIndexFile)).toEqual(nonIndexFile);
-    expect(getIndex(folderSegment)).toEqual({
-      type: "file",
-      path: joinFromRoot(
-        "project",
-        "src",
-        "entities",
-        "user",
-        "ui",
-        "index.server.js",
-      ),
-    });
+    expect(getIndex(indexServerFile)).toEqual([indexServerFile]);
+    expect(getIndex(nonIndexFile)).toEqual([nonIndexFile]);
+    expect(getIndex(folderSegment)).toEqual([
+      {
+        type: "file",
+        path: joinFromRoot(
+          "project",
+          "src",
+          "entities",
+          "user",
+          "ui",
+          "index.server.js",
+        ),
+      },
+    ]);
+  });
+
+  test("handles multiple index files", () => {
+    const folderSegment = parseIntoFolder(
+      `
+      📄 Avatar.tsx
+      📄 User.tsx
+      📄 index.client.js
+      📄 index.server.js
+      `,
+      joinFromRoot("project", "src", "entities", "user", "ui"),
+    );
+
+    expect(getIndex(folderSegment)).toEqual([
+      {
+        type: "file",
+        path: joinFromRoot(
+          "project",
+          "src",
+          "entities",
+          "user",
+          "ui",
+          "index.client.js",
+        ),
+      },
+      {
+        type: "file",
+        path: joinFromRoot(
+          "project",
+          "src",
+          "entities",
+          "user",
+          "ui",
+          "index.server.js",
+        ),
+      },
+    ]);
   });
 });
 

--- a/src/specs/fsd-aware-traverse.spec.ts
+++ b/src/specs/fsd-aware-traverse.spec.ts
@@ -1,5 +1,5 @@
 import { join } from "node:path";
-import { test, expect } from "vitest";
+import { test, expect, describe } from "vitest";
 
 import {
   getAllSlices,
@@ -123,28 +123,70 @@ test("isSliced", () => {
   ).toBe(true);
 });
 
-test("getIndex", () => {
-  const indexFile: File = {
-    type: "file",
-    path: joinFromRoot("project", "src", "shared", "index.ts"),
-  };
-  const fileSegment: File = {
-    type: "file",
-    path: joinFromRoot("project", "src", "entities", "user", "ui.ts"),
-  };
-  const folderSegment = parseIntoFolder(
-    `
-    📄 Avatar.tsx
-    📄 User.tsx
-    📄 index.ts
-    `,
-    joinFromRoot("project", "src", "entities", "user", "ui"),
-  );
-  expect(getIndex(indexFile)).toEqual(indexFile);
-  expect(getIndex(fileSegment)).toEqual(fileSegment);
-  expect(getIndex(folderSegment)).toEqual({
-    type: "file",
-    path: joinFromRoot("project", "src", "entities", "user", "ui", "index.ts"),
+describe("getIndex", () => {
+  test("basic functionality", () => {
+    const indexFile: File = {
+      type: "file",
+      path: joinFromRoot("project", "src", "shared", "index.ts"),
+    };
+    const fileSegment: File = {
+      type: "file",
+      path: joinFromRoot("project", "src", "entities", "user", "ui.ts"),
+    };
+    const folderSegment = parseIntoFolder(
+      `
+      📄 Avatar.tsx
+      📄 User.tsx
+      📄 index.ts
+      `,
+      joinFromRoot("project", "src", "entities", "user", "ui"),
+    );
+    expect(getIndex(indexFile)).toEqual(indexFile);
+    expect(getIndex(fileSegment)).toEqual(fileSegment);
+    expect(getIndex(folderSegment)).toEqual({
+      type: "file",
+      path: joinFromRoot(
+        "project",
+        "src",
+        "entities",
+        "user",
+        "ui",
+        "index.ts",
+      ),
+    });
+  });
+
+  test("recognizes index.server.js as index file", () => {
+    const indexServerFile: File = {
+      type: "file",
+      path: joinFromRoot("project", "src", "shared", "index.server.js"),
+    };
+    const nonIndexFile: File = {
+      type: "file",
+      path: joinFromRoot("project", "src", "entities", "user", "ui.ts"),
+    };
+    const folderSegment = parseIntoFolder(
+      `
+      📄 Avatar.tsx
+      📄 User.tsx
+      📄 index.server.js
+      `,
+      joinFromRoot("project", "src", "entities", "user", "ui"),
+    );
+
+    expect(getIndex(indexServerFile)).toEqual(indexServerFile);
+    expect(getIndex(nonIndexFile)).toEqual(nonIndexFile);
+    expect(getIndex(folderSegment)).toEqual({
+      type: "file",
+      path: joinFromRoot(
+        "project",
+        "src",
+        "entities",
+        "user",
+        "ui",
+        "index.server.js",
+      ),
+    });
   });
 });
 

--- a/src/specs/fsd-aware-traverse.spec.ts
+++ b/src/specs/fsd-aware-traverse.spec.ts
@@ -3,7 +3,7 @@ import { test, expect, describe } from "vitest";
 
 import {
   getAllSlices,
-  getIndex,
+  getIndexes,
   getSlices,
   isSlice,
   isSliced,
@@ -123,7 +123,7 @@ test("isSliced", () => {
   ).toBe(true);
 });
 
-describe("getIndex", () => {
+describe("getIndexes", () => {
   test("basic functionality", () => {
     const indexFile: File = {
       type: "file",
@@ -141,9 +141,9 @@ describe("getIndex", () => {
       `,
       joinFromRoot("project", "src", "entities", "user", "ui"),
     );
-    expect(getIndex(indexFile)).toEqual([indexFile]);
-    expect(getIndex(fileSegment)).toEqual([fileSegment]);
-    expect(getIndex(folderSegment)).toEqual([
+    expect(getIndexes(indexFile)).toEqual([indexFile]);
+    expect(getIndexes(fileSegment)).toEqual([fileSegment]);
+    expect(getIndexes(folderSegment)).toEqual([
       {
         type: "file",
         path: joinFromRoot(
@@ -176,9 +176,9 @@ describe("getIndex", () => {
       joinFromRoot("project", "src", "entities", "user", "ui"),
     );
 
-    expect(getIndex(indexServerFile)).toEqual([indexServerFile]);
-    expect(getIndex(nonIndexFile)).toEqual([nonIndexFile]);
-    expect(getIndex(folderSegment)).toEqual([
+    expect(getIndexes(indexServerFile)).toEqual([indexServerFile]);
+    expect(getIndexes(nonIndexFile)).toEqual([nonIndexFile]);
+    expect(getIndexes(folderSegment)).toEqual([
       {
         type: "file",
         path: joinFromRoot(
@@ -204,7 +204,7 @@ describe("getIndex", () => {
       joinFromRoot("project", "src", "entities", "user", "ui"),
     );
 
-    expect(getIndex(folderSegment)).toEqual([
+    expect(getIndexes(folderSegment)).toEqual([
       {
         type: "file",
         path: joinFromRoot(


### PR DESCRIPTION
### Description
This PR updates the `isIndex` function to ensure that only files named exactly index (with any extension) are recognized as index files. This change prevents files like `index.server.js` from being incorrectly identified as `undefined` 
(related to https://github.com/feature-sliced/steiger/issues/180)

### Changes
Now the `isIndex` function checks not only for an exact match with index, but also ensures that the filename, when split by the dot separator, matches `index`.