### PR TITLE
Support index files in `isCrossImportPublicApi`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@feature-sliced/filesystem",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "A set of utilities for locating and working with FSD roots in the file system.",
   "scripts": {
     "build": "tsup src/index.ts --dts --format esm,cjs --clean",

--- a/src/fsd-aware-traverse.ts
+++ b/src/fsd-aware-traverse.ts
@@ -193,6 +193,11 @@ export function isCrossImportPublicApi(
   }: { inSlice: string; forSlice: string; layerPath: string },
 ): boolean {
   const { dir, name } = parse(file.path);
+
+  if (isIndex(file)) {
+    return dir === join(layerPath, inSlice, "@x", forSlice);
+  }
+
   return name === forSlice && dir === join(layerPath, inSlice, "@x");
 }
 

--- a/src/specs/fsd-aware-traverse.spec.ts
+++ b/src/specs/fsd-aware-traverse.spec.ts
@@ -260,6 +260,36 @@ test("isCrossImportPublicApi", () => {
   ).toBe(false);
 });
 
+test("isCrossImportPublicApi with index files", () => {
+  const indexFile: File = {
+    path: joinFromRoot(
+      "project",
+      "src",
+      "entities",
+      "user",
+      "@x",
+      "product",
+      "index.ts",
+    ),
+    type: "file",
+  };
+
+  expect(
+    isCrossImportPublicApi(indexFile, {
+      inSlice: "user",
+      forSlice: "product",
+      layerPath: joinFromRoot("project", "src", "entities"),
+    }),
+  ).toBe(true);
+  expect(
+    isCrossImportPublicApi(indexFile, {
+      inSlice: "product",
+      forSlice: "user",
+      layerPath: joinFromRoot("project", "src", "entities"),
+    }),
+  ).toBe(false);
+});
+
 test("isSlice", () => {
   const sliceFolder = parseIntoFolder(
     `


### PR DESCRIPTION
### Description
This PR enhances `isCrossImportPublicApi` to handle index files in cross-import folders
   - Now correctly identifies files like `./src/entities/user/@x/product/index.ts` as cross-imports
   - Added tests for this scenario

### Fixes
Fixes https://github.com/feature-sliced/steiger/issues/179