### PR TITLE
fix: strip ordering prefixes in isSliced

### DIFF
--- a/src/fsd-aware-traverse.ts
+++ b/src/fsd-aware-traverse.ts
@@ -184,9 +184,8 @@ export function getAllSegments(fsdRoot: Folder): Array<{
  * Only layers Shared and App are not sliced, the rest are.
  */
 export function isSliced(layerOrName: Folder | LayerName): boolean {
-  return !unslicedLayers.includes(
-    basename(typeof layerOrName === "string" ? layerOrName : layerOrName.path),
-  );
+  const name = typeof layerOrName === "string" ? layerOrName : layerOrName.path;
+  return !unslicedLayers.includes(removePrefix(basename(name)));
 }
 
 /**

--- a/src/specs/fsd-aware-traverse.spec.ts
+++ b/src/specs/fsd-aware-traverse.spec.ts
@@ -2,6 +2,7 @@ import { join } from "node:path";
 import { test, expect, describe } from "vitest";
 
 import {
+  getAllSegments,
   getAllSlices,
   getIndexes,
   getSlices,
@@ -150,6 +151,42 @@ test("isSliced", () => {
       children: [],
     }),
   ).toBe(true);
+});
+
+test("isSliced treats prefixed layers as their unprefixed counterparts", () => {
+  const prefixedLayer = (name: string): Folder => ({
+    type: "folder",
+    path: joinFromRoot("project", "src", name),
+    children: [],
+  });
+
+  expect(isSliced(prefixedLayer("_shared"))).toBe(false);
+  expect(isSliced(prefixedLayer("_app"))).toBe(false);
+  expect(isSliced(prefixedLayer("_entities"))).toBe(true);
+});
+
+test("getAllSegments traces segments of prefixed unsliced layers", () => {
+  const rootFolder = parseIntoFolder(`
+    📂 _app
+      📂 lib
+        📄 index.ts
+    📂 _shared
+      📂 ui
+        📄 index.ts
+  `);
+
+  const segments = getAllSegments(rootFolder).map(
+    ({ segmentName, sliceName, layerName }) => ({
+      segmentName,
+      sliceName,
+      layerName,
+    }),
+  );
+
+  expect(segments).toEqual([
+    { segmentName: "lib", sliceName: null, layerName: "app" },
+    { segmentName: "ui", sliceName: null, layerName: "shared" },
+  ]);
 });
 
 describe("getIndexes", () => {


### PR DESCRIPTION
## Problem

`isSliced()` compares the raw basename against `unslicedLayers` (`["shared", "app"]`) without stripping the FSD ordering prefix. A layer like `_app` (Next.js App Router) is therefore treated as sliced: `getAllSegments()` walks its children looking for slices, finds none, and the segments of `_app` are never indexed — so imports from `_app` files are never traced.

Downstream in steiger, this makes `fsd/insignificant-slice` report "no references" for a slice whose only consumer is in `_app`, and the App-layer exemption from steiger#153 never applies because zero references are traced.

## Fix

Reuse the existing `removePrefix()` helper (added in #9 for `getLayers`) when classifying a layer:

```ts
export function isSliced(layerOrName: Folder | LayerName): boolean {
  const name = typeof layerOrName === "string" ? layerOrName : layerOrName.path;
  return !unslicedLayers.includes(removePrefix(basename(name)));
}
```

## Tests

- `isSliced` recognizes `_shared` and `_app` as unsliced, `_entities` as sliced (via `Folder` paths — the production call shape).
- `getAllSegments` traces segments of prefixed unsliced layers (`_app/lib`, `_shared/ui`).

Both fail on main and pass with the fix. `pnpm test`, `pnpm lint`, `pnpm typecheck`, `pnpm format`, and `pnpm build` all pass.

Fixes #11
